### PR TITLE
feat: Rename PostgresJSONB to JSONB and PostgresUUID to UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python -m pip install ormar-postgres-extensions
 
 ### Fields
 
-Two native PG fields are provided. The `PostgresJSONB` and `PostgresUUID` types map to native `JSONB` and `UUID` data types respectively. Using these in an Ormar model is as simple as importing the fields and using them in the model.
+Two native PG fields are provided. The `JSONB` and `UUID` types map to native `JSONB` and `UUID` data types respectively. Using these in an Ormar model is as simple as importing the fields and using them in the model.
 
 ```python
 from uuid import UUID

--- a/src/ormar_postgres_extensions/__init__.py
+++ b/src/ormar_postgres_extensions/__init__.py
@@ -1,4 +1,4 @@
 from .fields import (  # noqa: F401
-    PostgresJSONB,
-    PostgresUUID,
+    JSONB,
+    UUID,
 )

--- a/src/ormar_postgres_extensions/fields/__init__.py
+++ b/src/ormar_postgres_extensions/fields/__init__.py
@@ -1,2 +1,2 @@
-from .jsonb import PostgresJSONB  # noqa: F401
-from .uuid import PostgresUUID  # noqa: F401
+from .jsonb import JSONB  # noqa: F401
+from .uuid import UUID  # noqa: F401

--- a/src/ormar_postgres_extensions/fields/jsonb.py
+++ b/src/ormar_postgres_extensions/fields/jsonb.py
@@ -9,7 +9,7 @@ class PostgresJSONBTypeDecorator(TypeDecorator):
     impl = postgresql.JSONB
 
 
-class PostgresJSONB(ormar.JSON):
+class JSONB(ormar.JSON):
     """
     Custom JSON field uses a native PG JSONB type
     """

--- a/src/ormar_postgres_extensions/fields/uuid.py
+++ b/src/ormar_postgres_extensions/fields/uuid.py
@@ -39,7 +39,7 @@ class PostgresUUIDTypeDecorator(TypeDecorator):
         return value
 
 
-class PostgresUUID(ormar.UUID):
+class UUID(ormar.UUID):
     """
     Custom UUID field for the schema that uses a native PG UUID type
     """

--- a/tests/fields/test_jsonb.py
+++ b/tests/fields/test_jsonb.py
@@ -4,7 +4,7 @@ from typing import Optional
 import ormar
 import pytest
 
-from ormar_postgres_extensions.fields import PostgresJSONB
+from ormar_postgres_extensions.fields import JSONB
 from tests.database import (
     database,
     metadata,
@@ -17,7 +17,7 @@ class JSONBTestModel(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    data: dict = PostgresJSONB()
+    data: dict = JSONB()
 
 
 class NullableJSONBTestModel(ormar.Model):
@@ -26,7 +26,7 @@ class NullableJSONBTestModel(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    data: Optional[dict] = PostgresJSONB(nullable=True)
+    data: Optional[dict] = JSONB(nullable=True)
 
 
 @pytest.mark.asyncio

--- a/tests/fields/test_uuid.py
+++ b/tests/fields/test_uuid.py
@@ -7,7 +7,7 @@ from uuid import (
 import ormar
 import pytest
 
-from ormar_postgres_extensions.fields import PostgresUUID
+from ormar_postgres_extensions.fields import UUID as UUIDField
 from tests.database import (
     database,
     metadata,
@@ -20,7 +20,7 @@ class UUIDTestModel(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    uid: UUID = PostgresUUID(default=uuid4)
+    uid: UUID = UUIDField(default=uuid4)
 
 
 class NullableUUIDTestModel(ormar.Model):
@@ -29,7 +29,7 @@ class NullableUUIDTestModel(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    uid: Optional[UUID] = PostgresUUID(nullable=True)
+    uid: Optional[UUID] = UUIDField(nullable=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Renames `fields.PostgresJSONB` to `fields.JSONB` and `fields.PostgresUUID` to `fields.UUID`. These new names seem more appropriate