### PR TITLE
simplify array field options and imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ ENV/
 env.bak/
 venv.bak/
 .vscode
+
+.idea

--- a/README.md
+++ b/README.md
@@ -28,25 +28,35 @@ python -m pip install ormar-postgres-extensions
 
 Three native PG fields are provided. The `JSONB` and `UUID` types map to native `JSONB` and `UUID` data types respectively. The `Array` type can be used to create an array column. Using these in an Ormar model is as simple as importing the fields and using them in the model.
 
+#### UUID
+
 ```python
 from uuid import UUID
 
 import ormar
-from ormar_postgres_extensions import PostgresUUID
+import ormar_postgres_extensions as ormar_pg_ext
 
 
 class MyModel(ormar.Model):
-    uid: UUID = PostgresUUID(unique=True, nullable=False)
+    uuid: UUID = ormar_pg_ext.UUID(unique=True, nullable=False)
 ```
+#### JSONB
+```python
+import ormar
+import ormar_postgres_extensions as ormar_pg_ext
 
-#### Array Fields
+class JSONBTestModel(ormar.Model):
+    id: int = ormar.Integer(primary_key=True)
+    data: dict = ormar_pg_ext.JSONB()
+```
+#### Array
 
-Array fields require a bit more setup to pass the type of the array into the field
+Array field requires a bit more setup to pass the type of the array into the field
 
 ```python
 import ormar
 import sqlalchemy
-from ormar_postgres_extensions import Array
+import ormar_postgres_extensions as ormar_pg_ext
 
 class ModelWithArray(ormar.Model):
     class Meta:
@@ -54,7 +64,7 @@ class ModelWithArray(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    data: list = Array(item_type=sqlalchemy.String())
+    data: list = ormar_pg_ext.ARRAY(item_type=sqlalchemy.String())
 ```
 
 Arrays have access to three special methods that map to specific PostgreSQL array functions
@@ -64,9 +74,7 @@ Arrays have access to three special methods that map to specific PostgreSQL arra
 The maps to the [`contained_by`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.ARRAY.Comparator.contained_by) operator in Postgres.
 
 ```python
-await ModelWithArray.objects.filter(
-  ModelWithArray.data.array_contained_by(["a"])
-).all()
+await ModelWithArray.objects.filter(data__array_contained_by=["a"]).all()
 ```
 
 ##### array_contains
@@ -74,9 +82,7 @@ await ModelWithArray.objects.filter(
 The maps to the [`contains`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.ARRAY.Comparator.contains) operator in Postgres.
 
 ```python
-await ModelWithArray.objects.filter(
-  ModelWithArray.data.array_contains(["a"])
-).all()
+await ModelWithArray.objects.filter(data__array_contains=["a"]).all()
 ```
 
 ##### array_overlap
@@ -84,9 +90,7 @@ await ModelWithArray.objects.filter(
 The maps to the [`overlap`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.ARRAY.Comparator.overlap) operator in Postgres.
 
 ```python
-await ModelWithArray.objects.filter(
-  ModelWithArray.data.array_overlap(["a"])
-).all()
+await ModelWithArray.objects.filter(data__array_overlap=["a"]).all()
 ```
 
 ## Uninstalling

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -11,7 +11,7 @@ asyncpg==0.25.0
     # via databases
 attrs==21.4.0
     # via pytest
-black==21.12b0
+black==22.1.0
     # via ormar-postgres-extensions
 bleach==4.1.0
     # via readme-renderer

--- a/tests/fields/test_jsonb.py
+++ b/tests/fields/test_jsonb.py
@@ -4,7 +4,7 @@ from typing import Optional
 import ormar
 import pytest
 
-from ormar_postgres_extensions.fields import JSONB
+import ormar_postgres_extensions as ormar_pg_ext
 from tests.database import (
     database,
     metadata,
@@ -17,7 +17,7 @@ class JSONBTestModel(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    data: dict = JSONB()
+    data: dict = ormar_pg_ext.JSONB()
 
 
 class NullableJSONBTestModel(ormar.Model):
@@ -26,7 +26,7 @@ class NullableJSONBTestModel(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    data: Optional[dict] = JSONB(nullable=True)
+    data: Optional[dict] = ormar_pg_ext.JSONB(nullable=True)
 
 
 @pytest.mark.asyncio

--- a/tests/fields/test_uuid.py
+++ b/tests/fields/test_uuid.py
@@ -7,7 +7,7 @@ from uuid import (
 import ormar
 import pytest
 
-from ormar_postgres_extensions.fields import UUID as UUIDField
+import ormar_postgres_extensions as ormar_pg_ext
 from tests.database import (
     database,
     metadata,
@@ -20,7 +20,7 @@ class UUIDTestModel(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    uid: UUID = UUIDField(default=uuid4)
+    uid: UUID = ormar_pg_ext.UUID(default=uuid4)
 
 
 class NullableUUIDTestModel(ormar.Model):
@@ -29,7 +29,7 @@ class NullableUUIDTestModel(ormar.Model):
         metadata = metadata
 
     id: int = ormar.Integer(primary_key=True)
-    uid: Optional[UUID] = UUIDField(nullable=True)
+    uid: Optional[UUID] = ormar_pg_ext.UUID(nullable=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Following aesthetic changes are made in the PR:
1. For Array field replace:
```python
await ModelWithArray.objects.filter(
  ModelWithArray.data.array_contained_by(["a"])
).all()
```
with
```python
await ModelWithArray.objects.filter(data__array_contained_by=["a"]).all()
```
2. Tests import extension fields as
```python
import ormar_postgres_extensions as ormar_pg_ext
```
so fields can be used as
```python
ormar_pg_ext.ARRAY(item_type=sqlalchemy.String())
```
without field-level aliasing.
3. Added more tests cases for Array field.
4. Updated Readme and black version.

## Related Issues

- Closes #14

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
