### PR TITLE
Additional jsonb operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ The maps to the [`contains`](https://docs.sqlalchemy.org/en/14/dialects/postgres
 await JSONBTestModel.objects.filter(data__jsonb_contains=dict(key="value")).all()
 ```
 
+##### jsonb_has_all
+
+The maps to the [`has_all`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSONB.Comparator.has_all) operator in Postgres.
+
+```python
+from sqlalchemy.dialects.postgres import array
+
+await JSONBTestModel.objects.filter(data__jsonb_has_all=array(["key1", "key2"])).all()
+```
+
+##### jsonb_has_any
 ##### jsonb_has_key
 
 The maps to the [`has_key`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSONB.Comparator.has_key) operator in Postgres.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ The maps to the [`contains`](https://docs.sqlalchemy.org/en/14/dialects/postgres
 await JSONBTestModel.objects.filter(data__jsonb_contains=dict(key="value")).all()
 ```
 
+##### jsonb_has_key
+
+The maps to the [`has_key`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSONB.Comparator.has_key) operator in Postgres.
+
+```python
+await JSONBTestModel.objects.filter(data__jsonb_has_key="key1").all()
+```
+
 #### Array
 
 Array field requires a bit more setup to pass the type of the array into the field

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ class JSONBTestModel(ormar.Model):
     data: dict = ormar_pg_ext.JSONB()
 ```
 
+##### jsonb_contained_by
+
+The maps to the [`contains`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSONB.Comparator.contained_by) operator in Postgres.
+
+```python
+await JSONBTestModel.objects.filter(data__jsonb_contained_by=dict(key="value")).all()
+```
+
 ##### jsonb_contains
 
 The maps to the [`contains`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSONB.Comparator.contains) operator in Postgres.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ await JSONBTestModel.objects.filter(data__jsonb_has_all=array(["key1", "key2"]))
 ```
 
 ##### jsonb_has_any
+
+The maps to the [`has_any`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSONB.Comparator.has_any) operator in Postgres.
+
+```python
+from sqlalchemy.dialects.postgres import array
+
+await JSONBTestModel.objects.filter(data__jsonb_has_any=array(["key1", "key2"])).all()
+```
+
 ##### jsonb_has_key
 
 The maps to the [`has_key`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSONB.Comparator.has_key) operator in Postgres.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ class JSONBTestModel(ormar.Model):
     id: int = ormar.Integer(primary_key=True)
     data: dict = ormar_pg_ext.JSONB()
 ```
+
+##### jsonb_contains
+
+The maps to the [`contains`](https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSONB.Comparator.contains) operator in Postgres.
+
+```python
+await JSONBTestModel.objects.filter(data__jsonb_contains=dict(key="value")).all()
+```
+
 #### Array
 
 Array field requires a bit more setup to pass the type of the array into the field

--- a/src/ormar_postgres_extensions/fields/jsonb.py
+++ b/src/ormar_postgres_extensions/fields/jsonb.py
@@ -37,6 +37,17 @@ def jsonb_has_all(self, other: Any) -> ormar.queryset.clause.FilterGroup:
     return self._select_operator(op="jsonb_has_all", other=other)
 
 
+def jsonb_has_any(self, other: Any) -> ormar.queryset.clause.FilterGroup:
+    """
+    works as postgresql `column ?| VALUE::jsonb`
+    :param other: value to check against operator
+    :type other: Any
+    :return: FilterGroup for operator
+    :rtype: ormar.queryset.clause.FilterGroup
+    """
+    return self._select_operator(op="jsonb_has_any", other=other)
+
+
 def jsonb_has_key(self, other: Any) -> ormar.queryset.clause.FilterGroup:
     """
     works as postgresql `column ? VALUE::jsonb`
@@ -53,6 +64,7 @@ FIELD_ACCESSOR_MAP = [
     ("jsonb_contained_by", jsonb_contained_by),
     ("jsonb_contains", jsonb_contains),
     ("jsonb_has_all", jsonb_has_all),
+    ("jsonb_has_any", jsonb_has_any),
     ("jsonb_has_key", jsonb_has_key),
 ]
 
@@ -67,6 +79,7 @@ ACCESSOR_MAP = [
     ("jsonb_contained_by", "contained_by"),
     ("jsonb_contains", "contains"),
     ("jsonb_has_all", "has_all"),
+    ("jsonb_has_any", "has_any"),
     ("jsonb_has_key", "has_key"),
 ]
 

--- a/src/ormar_postgres_extensions/fields/jsonb.py
+++ b/src/ormar_postgres_extensions/fields/jsonb.py
@@ -4,6 +4,42 @@ import ormar
 from sqlalchemy.dialects import postgresql
 
 
+def jsonb_contains(self, other: Any) -> ormar.queryset.clause.FilterGroup:
+    """
+    works as postgresql `column @> VALUE::jsonb`
+    :param other: value to check against operator
+    :type other: Any
+    :return: FilterGroup for operator
+    :rtype: ormar.queryset.clause.FilterGroup
+    """
+    return self._select_operator(op="jsonb_contains", other=other)
+
+
+# Need to patch the filter objects to support JSONB specifc actions
+FIELD_ACCESSOR_MAP = [
+    ("jsonb_contains", jsonb_contains),
+]
+
+
+for (method_name, method) in FIELD_ACCESSOR_MAP:
+    setattr(ormar.queryset.FieldAccessor, method_name, method)
+
+
+# These lines allow Ormar to lookup the new filter methods and map
+# it to the correct PGSQL functions
+ACCESSOR_MAP = [
+    ("jsonb_contains", "contains"),
+]
+
+for (ormar_operation, pg_operation) in ACCESSOR_MAP:
+    ormar.queryset.actions.filter_action.FILTER_OPERATORS[
+        ormar_operation
+    ] = pg_operation
+    ormar.queryset.actions.filter_action.METHODS_TO_OPERATORS[
+        ormar_operation
+    ] = ormar_operation
+
+
 class JSONB(ormar.JSON):
     """
     Custom JSON field uses a native PG JSONB type

--- a/src/ormar_postgres_extensions/fields/jsonb.py
+++ b/src/ormar_postgres_extensions/fields/jsonb.py
@@ -26,10 +26,22 @@ def jsonb_contains(self, other: Any) -> ormar.queryset.clause.FilterGroup:
     return self._select_operator(op="jsonb_contains", other=other)
 
 
+def jsonb_has_key(self, other: Any) -> ormar.queryset.clause.FilterGroup:
+    """
+    works as postgresql `column ? VALUE::jsonb`
+    :param other: value to check against operator
+    :type other: Any
+    :return: FilterGroup for operator
+    :rtype: ormar.queryset.clause.FilterGroup
+    """
+    return self._select_operator(op="jsonb_has_key", other=other)
+
+
 # Need to patch the filter objects to support JSONB specifc actions
 FIELD_ACCESSOR_MAP = [
     ("jsonb_contained_by", jsonb_contained_by),
     ("jsonb_contains", jsonb_contains),
+    ("jsonb_has_key", jsonb_has_key),
 ]
 
 
@@ -42,6 +54,7 @@ for (method_name, method) in FIELD_ACCESSOR_MAP:
 ACCESSOR_MAP = [
     ("jsonb_contained_by", "contained_by"),
     ("jsonb_contains", "contains"),
+    ("jsonb_has_key", "has_key"),
 ]
 
 for (ormar_operation, pg_operation) in ACCESSOR_MAP:

--- a/src/ormar_postgres_extensions/fields/jsonb.py
+++ b/src/ormar_postgres_extensions/fields/jsonb.py
@@ -26,6 +26,17 @@ def jsonb_contains(self, other: Any) -> ormar.queryset.clause.FilterGroup:
     return self._select_operator(op="jsonb_contains", other=other)
 
 
+def jsonb_has_all(self, other: Any) -> ormar.queryset.clause.FilterGroup:
+    """
+    works as postgresql `column ?& VALUE::jsonb`
+    :param other: value to check against operator
+    :type other: Any
+    :return: FilterGroup for operator
+    :rtype: ormar.queryset.clause.FilterGroup
+    """
+    return self._select_operator(op="jsonb_has_all", other=other)
+
+
 def jsonb_has_key(self, other: Any) -> ormar.queryset.clause.FilterGroup:
     """
     works as postgresql `column ? VALUE::jsonb`
@@ -41,6 +52,7 @@ def jsonb_has_key(self, other: Any) -> ormar.queryset.clause.FilterGroup:
 FIELD_ACCESSOR_MAP = [
     ("jsonb_contained_by", jsonb_contained_by),
     ("jsonb_contains", jsonb_contains),
+    ("jsonb_has_all", jsonb_has_all),
     ("jsonb_has_key", jsonb_has_key),
 ]
 
@@ -54,6 +66,7 @@ for (method_name, method) in FIELD_ACCESSOR_MAP:
 ACCESSOR_MAP = [
     ("jsonb_contained_by", "contained_by"),
     ("jsonb_contains", "contains"),
+    ("jsonb_has_all", "has_all"),
     ("jsonb_has_key", "has_key"),
 ]
 

--- a/src/ormar_postgres_extensions/fields/jsonb.py
+++ b/src/ormar_postgres_extensions/fields/jsonb.py
@@ -4,6 +4,17 @@ import ormar
 from sqlalchemy.dialects import postgresql
 
 
+def jsonb_contained_by(self, other: Any) -> ormar.queryset.clause.FilterGroup:
+    """
+    works as postgresql `column <@ VALUE::jsonb`
+    :param other: value to check against operator
+    :type other: Any
+    :return: FilterGroup for operator
+    :rtype: ormar.queryset.clause.FilterGroup
+    """
+    return self._select_operator(op="jsonb_contained_by", other=other)
+
+
 def jsonb_contains(self, other: Any) -> ormar.queryset.clause.FilterGroup:
     """
     works as postgresql `column @> VALUE::jsonb`
@@ -17,6 +28,7 @@ def jsonb_contains(self, other: Any) -> ormar.queryset.clause.FilterGroup:
 
 # Need to patch the filter objects to support JSONB specifc actions
 FIELD_ACCESSOR_MAP = [
+    ("jsonb_contained_by", jsonb_contained_by),
     ("jsonb_contains", jsonb_contains),
 ]
 
@@ -28,6 +40,7 @@ for (method_name, method) in FIELD_ACCESSOR_MAP:
 # These lines allow Ormar to lookup the new filter methods and map
 # it to the correct PGSQL functions
 ACCESSOR_MAP = [
+    ("jsonb_contained_by", "contained_by"),
     ("jsonb_contains", "contains"),
 ]
 

--- a/tests/fields/test_jsonb.py
+++ b/tests/fields/test_jsonb.py
@@ -100,3 +100,24 @@ async def test_contains_array_text(db):
 
     found = await JSONBTestModel.objects.filter(data__jsonb_contains="4").all()
     assert len(found) == 0
+
+
+@pytest.mark.asyncio
+async def test_contained_by(db):
+    await JSONBTestModel(data=json.dumps(dict(key1="foo"))).save()
+    await JSONBTestModel(data=json.dumps(dict(key2="bar"))).save()
+
+    found = await JSONBTestModel.objects.filter(
+        data__jsonb_contained_by=dict(key1="foo")
+    ).all()
+    assert len(found) == 1
+
+    found = await JSONBTestModel.objects.filter(
+        data__jsonb_contained_by=dict(key1="foo", key2="bar")
+    ).all()
+    assert len(found) == 2
+
+    found = await JSONBTestModel.objects.filter(
+        data__jsonb_contains=dict(key1="bar")
+    ).all()
+    assert len(found) == 0

--- a/tests/fields/test_jsonb.py
+++ b/tests/fields/test_jsonb.py
@@ -121,3 +121,27 @@ async def test_contained_by(db):
         data__jsonb_contains=dict(key1="bar")
     ).all()
     assert len(found) == 0
+
+
+@pytest.mark.asyncio
+async def test_has_key_object(db):
+    await JSONBTestModel(data=json.dumps(dict(key1="foo"))).save()
+    await JSONBTestModel(data=json.dumps(dict(key2="bar"))).save()
+
+    found = await JSONBTestModel.objects.filter(data__jsonb_has_key="key1").all()
+    assert len(found) == 1
+
+    found = await JSONBTestModel.objects.filter(data__jsonb_has_key="key3").all()
+    assert len(found) == 0
+
+
+@pytest.mark.asyncio
+async def test_has_key_array(db):
+    await JSONBTestModel(data=json.dumps(["foo"])).save()
+    await JSONBTestModel(data=json.dumps(["bar"])).save()
+
+    found = await JSONBTestModel.objects.filter(data__jsonb_has_key="foo").all()
+    assert len(found) == 1
+
+    found = await JSONBTestModel.objects.filter(data__jsonb_has_key="other").all()
+    assert len(found) == 0

--- a/tests/fields/test_jsonb.py
+++ b/tests/fields/test_jsonb.py
@@ -146,6 +146,27 @@ async def test_has_all(db):
 
 
 @pytest.mark.asyncio
+async def test_has_any(db):
+    await JSONBTestModel(data=json.dumps(dict(key1="foo", key3=2))).save()
+    await JSONBTestModel(data=json.dumps(dict(key2="bar"))).save()
+
+    found = await JSONBTestModel.objects.filter(
+        data__jsonb_has_any=array(["key1"])
+    ).all()
+    assert len(found) == 1
+
+    found = await JSONBTestModel.objects.filter(
+        data__jsonb_has_any=array(["key1", "key3"])
+    ).all()
+    assert len(found) == 1
+
+    found = await JSONBTestModel.objects.filter(
+        data__jsonb_has_any=array(["key1", "key2"])
+    ).all()
+    assert len(found) == 2
+
+
+@pytest.mark.asyncio
 async def test_has_key_object(db):
     await JSONBTestModel(data=json.dumps(dict(key1="foo"))).save()
     await JSONBTestModel(data=json.dumps(dict(key2="bar"))).save()


### PR DESCRIPTION
## Description

Adds additional JSONB operators:

* contains, `@>`
* contained_by, `<@`
* has_all, `?&`
* has_any, `?|`
* has_key, `?` 

## Checklist

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

