### PR TITLE
feat: allow pydantic 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup_requires = ["setuptools_scm"]
 install_requires = [
     "databases[postgresql]>=0.5.4,<1.0.0",
     "ormar>=0.10.24,<1.0.0",
-    "pydantic>=1.9.0,<2.0.0",
+    "pydantic>=1.9.0",
     "sqlalchemy>=1.4.29,<2.0.0",
 ]
 test_requires = [


### PR DESCRIPTION
## Description

The project currently requires pydantic < 2, but it's actually compatible with Pydantic 2 now that Ormar supports it.
## Related Issues

<!-- Does this PR directly address an existing GitHub issue? If not, you may want to consider creating an issue first. -->

- Closes https://github.com/tophat/ormar-postgres-extensions/issues/32.

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

Should I update the README in this PR?