### PR TITLE
fix: update codecov dep to 2.1.13

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -27,7 +27,7 @@ click==8.1.3
     # via
     #   black
     #   pip-tools
-codecov==2.1.12
+codecov==2.1.13
     # via ormar-postgres-extensions
 commonmark==0.9.1
     # via rich


### PR DESCRIPTION
## Description

See https://about.codecov.io/blog/message-regarding-the-pypi-package/. Ideally this project should upgrade to the new codecov-cli or github action, but for now this should unblock tests.

## Related Issues

## Checklist

<!-- Please mark items as completed where appropriate. e.g. [x]. -->

- [x] This PR has sufficient documentation.
- [x] This PR has sufficient test coverage.
- [x] This PR title satisfies semantic [convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

## Additional Comments

<!-- Feel free to add any additional comments related to this PR. -->

No additional comments.
